### PR TITLE
Better test coverage

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -267,7 +267,7 @@ describe('gulpTateru', () => {
 
   it('should apply both formatter and minify functions together', async () => {
     const formatter: Formatter = async (contents, fileType) =>
-      await `FORMATTED (${fileType}): ${contents}`;
+      `FORMATTED (${fileType}): ${contents}`;
     const minify: Minify = async (contents) => contents.replace(/\s+/g, ' ');
 
     const { generatedFile } = await new Promise<{
@@ -300,7 +300,7 @@ describe('gulpTateru', () => {
   it('should handle different file types correctly', async () => {
     const formatterCalls: { contents: string; fileType: string }[] = [];
     const formatter: Formatter = async (contents, fileType) => {
-      await formatterCalls.push({ contents, fileType: fileType ?? 'unknown' });
+      formatterCalls.push({ contents, fileType: fileType ?? 'unknown' });
       return contents;
     };
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -301,7 +301,7 @@ describe('gulpTateru', () => {
     const formatterCalls: { contents: string; fileType: string }[] = [];
     const formatter: Formatter = async (contents, fileType) => {
       formatterCalls.push({ contents, fileType: fileType ?? 'unknown' });
-      return contents;
+      return Promise.resolve(contents);
     };
 
     await new Promise<void>((resolve) => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -267,7 +267,7 @@ describe('gulpTateru', () => {
 
   it('should apply both formatter and minify functions together', async () => {
     const formatter: Formatter = async (contents, fileType) =>
-      `FORMATTED (${fileType}): ${contents}`;
+      await `FORMATTED (${fileType}): ${contents}`;
     const minify: Minify = async (contents) => contents.replace(/\s+/g, ' ');
 
     const { generatedFile } = await new Promise<{
@@ -298,9 +298,9 @@ describe('gulpTateru', () => {
   });
 
   it('should handle different file types correctly', async () => {
-    const formatterCalls: Array<{ contents: string; fileType: string }> = [];
+    const formatterCalls: { contents: string; fileType: string }[] = [];
     const formatter: Formatter = async (contents, fileType) => {
-      formatterCalls.push({ contents, fileType: fileType || 'unknown' });
+      await formatterCalls.push({ contents, fileType: fileType ?? 'unknown' });
       return contents;
     };
 
@@ -391,7 +391,7 @@ describe('gulpTateru', () => {
   });
 
   it('should handle async formatter and minify functions', async () => {
-    const formatter: Formatter = async (contents, fileType) => {
+    const formatter: Formatter = async (contents) => {
       // Simulate async operation
       await new Promise((resolve) => setTimeout(resolve, 1));
       return `ASYNC_FORMATTED: ${contents}`;

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -244,4 +244,189 @@ describe('gulpTateru', () => {
     expect(error).toBeInstanceOf(PluginError);
     expect((error as PluginError).plugin).toBe('gulp-tateru-cli');
   });
+
+  it('should work with env option independently', async () => {
+    const { count } = await new Promise<{
+      count: number;
+    }>((resolve) => {
+      let n = 0;
+
+      gulp
+        .src('./tateru.config.json', { cwd: 'test/fixtures' })
+        .pipe(gulpTateruCli({ env: 'dev' }))
+        .on('data', () => {
+          n++;
+        })
+        .on('end', () => {
+          resolve({ count: n });
+        });
+    });
+
+    expect(count).toBe(6);
+  });
+
+  it('should apply both formatter and minify functions together', async () => {
+    const formatter: Formatter = async (contents, fileType) =>
+      `FORMATTED (${fileType}): ${contents}`;
+    const minify: Minify = async (contents) => contents.replace(/\s+/g, ' ');
+
+    const { generatedFile } = await new Promise<{
+      generatedFile: string;
+    }>((resolve) => {
+      let generatedFile: string;
+
+      gulp
+        .src('./tateru.config.json', { cwd: 'test/fixtures' })
+        .pipe(
+          gulpTateruCli({
+            formatter,
+            minify,
+            page: 'about',
+            env: 'prod',
+          })
+        )
+        .on('data', (file) => {
+          generatedFile = file.contents.toString();
+        })
+        .on('end', () => {
+          resolve({ generatedFile });
+        });
+    });
+
+    expect(generatedFile).toContain('FORMATTED (html):');
+    expect(generatedFile).not.toMatch(/\s{2,}/); // No multiple spaces
+  });
+
+  it('should handle different file types correctly', async () => {
+    const formatterCalls: Array<{ contents: string; fileType: string }> = [];
+    const formatter: Formatter = async (contents, fileType) => {
+      formatterCalls.push({ contents, fileType: fileType || 'unknown' });
+      return contents;
+    };
+
+    await new Promise<void>((resolve) => {
+      gulp
+        .src('./tateru.config.json', { cwd: 'test/fixtures' })
+        .pipe(gulpTateruCli({ formatter }))
+        .on('data', () => {
+          // Just collect files
+        })
+        .on('end', () => {
+          resolve();
+        });
+    });
+
+    const fileTypes = formatterCalls.map((call) => call.fileType);
+    expect(fileTypes).toContain('html');
+    expect(fileTypes).toContain('txt');
+    expect(fileTypes).toContain('xml');
+    expect(fileTypes).toContain('webmanifest');
+  });
+
+  it('should set correct vinyl file properties', async () => {
+    const files: Vinyl[] = [];
+
+    await new Promise<void>((resolve) => {
+      gulp
+        .src('./tateru.config.json', { cwd: 'test/fixtures' })
+        .pipe(gulpTateruCli({ page: 'about' }))
+        .on('data', (file) => {
+          files.push(file);
+        })
+        .on('end', () => {
+          resolve();
+        });
+    });
+
+    expect(files).toHaveLength(1);
+    const file = files[0];
+
+    expect(file).toBeInstanceOf(Vinyl);
+    expect(file.contents).toBeInstanceOf(Buffer);
+    expect(file.path).toBeTruthy();
+    expect(file.base).toBeTruthy();
+    expect(file.cwd).toBeTruthy();
+  });
+
+  it('should handle nonexistent page gracefully', async () => {
+    const { count } = await new Promise<{
+      count: number;
+    }>((resolve) => {
+      let n = 0;
+
+      gulp
+        .src('./tateru.config.json', { cwd: 'test/fixtures' })
+        .pipe(gulpTateruCli({ page: 'nonexistent-page' }))
+        .on('data', () => {
+          n++;
+        })
+        .on('end', () => {
+          resolve({ count: n });
+        });
+    });
+
+    // Should generate 0 files for nonexistent page
+    expect(count).toBe(0);
+  });
+
+  it('should handle nonexistent language gracefully', async () => {
+    const { count } = await new Promise<{
+      count: number;
+    }>((resolve) => {
+      let n = 0;
+
+      gulp
+        .src('./tateru.config.json', { cwd: 'test/fixtures' })
+        .pipe(gulpTateruCli({ lang: 'nonexistent-lang' }))
+        .on('data', () => {
+          n++;
+        })
+        .on('end', () => {
+          resolve({ count: n });
+        });
+    });
+
+    // Should generate 0 files for nonexistent language
+    expect(count).toBe(0);
+  });
+
+  it('should handle async formatter and minify functions', async () => {
+    const formatter: Formatter = async (contents, fileType) => {
+      // Simulate async operation
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      return `ASYNC_FORMATTED: ${contents}`;
+    };
+
+    const minify: Minify = async (contents) => {
+      // Simulate async operation
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      return contents.replace(/\s+/g, '');
+    };
+
+    const { generatedFile } = await new Promise<{
+      generatedFile: string;
+    }>((resolve) => {
+      let generatedFile: string;
+
+      gulp
+        .src('./tateru.config.json', { cwd: 'test/fixtures' })
+        .pipe(
+          gulpTateruCli({
+            formatter,
+            minify,
+            page: 'about',
+            env: 'prod',
+          })
+        )
+        .on('data', (file) => {
+          generatedFile = file.contents.toString();
+        })
+        .on('end', () => {
+          resolve({ generatedFile });
+        });
+    });
+
+    expect(generatedFile).toContain('ASYNC_FORMATTED:');
+    expect(generatedFile).not.toMatch(/\s+/);
+  });
 });


### PR DESCRIPTION
This pull request significantly expands the test coverage for the `gulpTateruCli` plugin in `src/index.spec.ts`. The new tests cover various edge cases, error handling, and integration scenarios to ensure the plugin behaves correctly under different conditions and with different configuration options.

**Expanded test coverage and validation:**

* Added tests to verify that null files are passed through the plugin without processing, and that errors from the core function are properly emitted as `PluginError` instances.
* Added tests for handling the `env` option independently, and for simultaneous use of custom `formatter` and `minify` functions, ensuring they work together as expected.
* Introduced tests to confirm the correct handling of various file types, and to ensure that generated Vinyl files have the correct properties set.

**Robustness and edge-case handling:**

* Added tests to check that the plugin gracefully handles nonexistent pages and languages by not generating any files.
* Included tests for asynchronous custom `formatter` and `minify` functions to ensure the plugin supports async processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive test coverage for stream-based flows, including null-file passthrough, error propagation and PluginError behavior, environment-specific runs, and handling of missing pages/languages (zero outputs).
  * Validates formatter+minifier integration (sync and async), multi-file-type processing, produced file metadata and buffer contents, and various page/env/lang combinations with event-driven assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->